### PR TITLE
Seed RandomnessHelper with a fixed value for reproducible benchmarks

### DIFF
--- a/Source/Library/GeoGen.Utilities/RandomnessHelper.cs
+++ b/Source/Library/GeoGen.Utilities/RandomnessHelper.cs
@@ -9,9 +9,12 @@
         #region Instance
 
         /// <summary>
-        /// The instance of the random numbers generator.
+        /// The instance of the random numbers generator. Seeded with a fixed value so that
+        /// runs are reproducible: the prover verifies candidate theorems numerically against
+        /// random point layouts, and a clock-seeded RNG would let marginal (near-tolerance)
+        /// theorems flip verdicts between runs.
         /// </summary>
-        private static readonly Random _random = new Random();
+        private static readonly Random _random = new Random(0);
 
         #endregion
 


### PR DESCRIPTION
# Context
I've noticed that long runs were not deterministic.

I tried this
```
  Initial configuration:                                                                                                                                                                
                                                            
   Triangle: A, B, C                                                                                                                                                                    
   G = Centroid(A, B, C)
                                                                                                                                                                                        
  Iterations: 2                                             
  MaximalPoints: 2
  MaximalLines: 2
  MaximalCircles: 2
  SymmetryGenerationMode: GenerateBothSymmetricAndAsymmetric   
````
with all `Constructions` and it gave me non deterministic results.

# Change
Set fixed seed for random number generator.

# Testing
I've tested it by running above multiple times and checking that outputs are the same.