### PR TITLE
Seed loose-layout axioms into the theorem prover

### DIFF
--- a/Source/Library/GeoGen.Core/Configurations/LooseObjectHolder.cs
+++ b/Source/Library/GeoGen.Core/Configurations/LooseObjectHolder.cs
@@ -252,6 +252,38 @@ namespace GeoGen.Core
             _ => throw new GeoGenException($"Unhandled value of {nameof(LooseObjectLayout)}: {Layout}"),
         };
 
+        /// <summary>
+        /// Returns the theorems that hold by virtue of the layout itself — facts the prover would
+        /// otherwise have no axiomatic source for. The geometry constructor draws each layout to
+        /// satisfy these properties, but the prover only sees the constructed objects, so without
+        /// this hook the right-angle of a <see cref="RightTriangle"/> (for example) is invisible to it.
+        /// </summary>
+        /// <returns>The theorems implied by the layout. Empty for layouts with no such theorems.</returns>
+        public IReadOnlyList<Theorem> GetLayoutTheorems() => Layout switch
+        {
+            // ABC with the right angle at A: AB ⊥ AC
+            RightTriangle => new[]
+            {
+                new Theorem(TheoremType.PerpendicularLines, new[]
+                {
+                    new LineTheoremObject(LooseObjects[0], LooseObjects[1]),
+                    new LineTheoremObject(LooseObjects[0], LooseObjects[2])
+                })
+            },
+
+            // The four points lie on a circle by definition of the layout
+            CyclicQuadrilateral => new[]
+            {
+                new Theorem(TheoremType.ConcyclicPoints, LooseObjects[0], LooseObjects[1], LooseObjects[2], LooseObjects[3])
+            },
+
+            // No layout-level theorems for the rest
+            LineSegment or Triangle or Quadrilateral or LineAndPoint or LineAndTwoPoints => Array.Empty<Theorem>(),
+
+            // Unhandled cases
+            _ => throw new GeoGenException($"Unhandled value of {nameof(LooseObjectLayout)}: {Layout}"),
+        };
+
         #endregion
 
         #region HashCode and Equals

--- a/Source/Library/GeoGen.TheoremProver/TheoremProofTree/InferenceData/InferenceRuleType.cs
+++ b/Source/Library/GeoGen.TheoremProver/TheoremProofTree/InferenceData/InferenceRuleType.cs
@@ -31,6 +31,13 @@ namespace GeoGen.TheoremProver
         TrivialTheorem,
 
         /// <summary>
+        /// The theorem holds by definition of the configuration's <see cref="Core.LooseObjectLayout"/>.
+        /// For example, in <see cref="Core.LooseObjectLayout.RightTriangle"/> the lines from the
+        /// right-angle vertex to the other two vertices are perpendicular by definition of the layout.
+        /// </summary>
+        LayoutTheorem,
+
+        /// <summary>
         /// The theorem can be reformulated to another theorem using equalities.
         /// </summary>
         ReformulatedTheorem,

--- a/Source/Library/GeoGen.TheoremProver/TheoremProofTree/OutputFormatterExtensions.cs
+++ b/Source/Library/GeoGen.TheoremProver/TheoremProofTree/OutputFormatterExtensions.cs
@@ -91,6 +91,9 @@ namespace GeoGen.TheoremProver
                 // Case when it's a trivial consequence of the object's construction
                 TrivialTheorem => "trivial consequence of the object's construction",
 
+                // Case when the theorem holds by definition of the configuration's loose-object layout
+                LayoutTheorem => "true by definition of the configuration's layout",
+
                 // Case when the theorem has been inferred as a reformulation of another theorem using equalities
                 ReformulatedTheorem => "reformulation of a theorem using equalities",
 

--- a/Source/Library/GeoGen.TheoremProver/TheoremProver.cs
+++ b/Source/Library/GeoGen.TheoremProver/TheoremProver.cs
@@ -194,6 +194,10 @@ namespace GeoGen.TheoremProver
                     // And enumerate the results
                     .ToList();
 
+            // Pull theorems implied by the loose-object layout itself (e.g. RightTriangle's right
+            // angle). Without this seed the prover has no axiomatic source for layout-level facts.
+            var layoutTheorems = configuration.LooseObjectsHolder.GetLayoutTheorems();
+
             #region Proof builder initialization
 
             // Prepare a proof builder in case we are supposed to construct proofs
@@ -201,6 +205,9 @@ namespace GeoGen.TheoremProver
 
             // Mark trivial theorems to the proof builder in case we are supposed to construct proofs
             trivialTheorems.ForEach(theorem => proofBuilder?.AddImplication(TrivialTheorem, theorem, assumptions: Array.Empty<Theorem>()));
+
+            // Mark layout-derived theorems to the proof builder
+            layoutTheorems.ForEach(theorem => proofBuilder?.AddImplication(LayoutTheorem, theorem, assumptions: Array.Empty<Theorem>()));
 
             // Mark assumed theorems to the proof builder in case we are supposed to construct proofs
             provenTheorems.AllObjects.ForEach(theorem => proofBuilder?.AddImplication(AssumedProven, theorem, assumptions: Array.Empty<Theorem>()));
@@ -215,8 +222,8 @@ namespace GeoGen.TheoremProver
             // If we are supposed to assuming them proven...
             if (_settings.AssumeThatSimplifiableTheoremsAreTrue)
             {
-                // Go through unproven theorems except for trivial ones
-                foreach (var theoremToProve in theoremsToProve.AllObjects.Except(trivialTheorems))
+                // Go through unproven theorems except for trivial and layout ones
+                foreach (var theoremToProve in theoremsToProve.AllObjects.Except(trivialTheorems).Except(layoutTheorems))
                 {
                     // Find the redundant objects
                     var redundantObjects = theoremToProve.GetUnnecessaryObjects(configuration);
@@ -240,8 +247,8 @@ namespace GeoGen.TheoremProver
             // Prepare the set of theorems inferred from symmetry
             var theoremsInferredFromSymmetry = new List<Theorem>();
 
-            // Go throw the theorems that are already inferred, i.e. assumed proven, trivial and definable simpler ones
-            foreach (var provedTheorem in provenTheorems.AllObjects.Concat(trivialTheorems).Concat(theoremsDefinableSimpler))
+            // Go throw the theorems that are already inferred, i.e. assumed proven, trivial, layout and definable simpler ones
+            foreach (var provedTheorem in provenTheorems.AllObjects.Concat(trivialTheorems).Concat(layoutTheorems).Concat(theoremsDefinableSimpler))
             {
                 // Try to infer new theorems using this one
                 foreach (var inferredTheorem in provedTheorem.InferTheoremsFromSymmetry(configuration))
@@ -262,6 +269,8 @@ namespace GeoGen.TheoremProver
             var provedTheorems = provenTheorems.AllObjects
                 // And trivial ones
                 .Concat(trivialTheorems)
+                // And layout-derived ones
+                .Concat(layoutTheorems)
                 // And ones with redundant objects
                 .Concat(theoremsDefinableSimpler)
                 // And ones inferred from symmetry

--- a/Source/Tests/IntegrationTests/GeoGen.TheoremProver.IntegrationTest/Program.cs
+++ b/Source/Tests/IntegrationTests/GeoGen.TheoremProver.IntegrationTest/Program.cs
@@ -91,7 +91,9 @@ namespace GeoGen.TheoremProver.IntegrationTest
                 HiddenMidpoint(),
                 LineTangentToCircle(),
                 ConcurrencyViaObjectIntroduction(),
-                SimpleLineSegments()
+                SimpleLineSegments(),
+                RightTriangleHypotenuseMidpoint(),
+                BareCyclicQuadrilateral()
             }
             // Perform each
             .ForEach(configuration =>
@@ -310,6 +312,30 @@ namespace GeoGen.TheoremProver.IntegrationTest
 
             // Return the configuration
             return Configuration.DeriveFromObjects(Triangle, A, B, C, D, E, F, G);
+        }
+
+        private static Configuration RightTriangleHypotenuseMidpoint()
+        {
+            // Create objects
+            var A = new LooseConfigurationObject(Point);
+            var B = new LooseConfigurationObject(Point);
+            var C = new LooseConfigurationObject(Point);
+            var D = new ConstructedConfigurationObject(Midpoint, B, C);
+
+            // Return the configuration
+            return Configuration.DeriveFromObjects(RightTriangle, A, B, C, D);
+        }
+
+        private static Configuration BareCyclicQuadrilateral()
+        {
+            // Create objects
+            var A = new LooseConfigurationObject(Point);
+            var B = new LooseConfigurationObject(Point);
+            var C = new LooseConfigurationObject(Point);
+            var D = new LooseConfigurationObject(Point);
+
+            // Return the configuration
+            return Configuration.DeriveFromObjects(CyclicQuadrilateral, A, B, C, D);
         }
 
         #endregion


### PR DESCRIPTION
# Context
The prover treated trivial theorems as the only zero-cost axioms, so facts implied by the loose-object layout itself (RightTriangle's right angle, CyclicQuadrilateral's concyclicity) had no axiomatic source and ended up unproved even though the geometry constructor draws them.

Add LooseObjectHolder.GetLayoutTheorems() and seed its output alongside trivial theorems with a new InferenceRuleType.LayoutTheorem.

# Testing
I've added those configurations to integration test and checked that they are proved now.