### PR TITLE
Identify the center of a circle with its constructive definition

### DIFF
--- a/Source/Library/GeoGen.TheoremProver.InferenceRuleProvider/Rules/ObjectSpecificRules/EqualityRules/Constructions/center_of_circle_with_center.txt
+++ b/Source/Library/GeoGen.TheoremProver.InferenceRuleProvider/Rules/ObjectSpecificRules/EqualityRules/Constructions/center_of_circle_with_center.txt
@@ -1,0 +1,9 @@
+﻿Objects:
+
+ c = CircleWithCenterThroughPoint(O, A)
+
+Theorems:
+
+Implications:
+
+ () => EqualObjects: O, CenterOfCircle(c)

--- a/Source/Library/GeoGen.TheoremProver.InferenceRuleProvider/Rules/ObjectSpecificRules/EqualityRules/Constructions/center_of_circle_with_diameter.txt
+++ b/Source/Library/GeoGen.TheoremProver.InferenceRuleProvider/Rules/ObjectSpecificRules/EqualityRules/Constructions/center_of_circle_with_diameter.txt
@@ -1,0 +1,9 @@
+﻿Objects:
+
+ c = CircleWithDiameter(A, B)
+
+Theorems:
+
+Implications:
+
+ () => EqualObjects: Midpoint(A, B), CenterOfCircle(c)


### PR DESCRIPTION
CircleWithCenterThroughPoint(O, A) and CircleWithDiameter(A, B) are the only two ways to construct a circle whose center is known by definition, but the prover had no rule connecting CenterOfCircle(...) to that center. This left configurations like c = CircleWithDiameter(A, D), E = CenterOfCircle(c) unable to derive E = Midpoint(A, D), so even trivial follow-ups like CollinearPoints: A, D, E went unproved.

Add two rules in the same shape as the existing Incircle/Excircle entries in EqualityRules/Constructions/.